### PR TITLE
Added check if config files exists - fixed issue #2

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -297,8 +297,8 @@ async function uploadCommand() {
 
     let config = new Config();
     config.settings = read('settings.json');
-    config.keybindings = read('keybindings.json');
-    config.locale = read('locale.json');
+    fs.exists('keybindings.json', (exists) => { if(exists) { config.keybindings = read('keybindings.json')}});
+    fs.exists('locale.json', (exists) => { if(exists) { config.keybindings = read('locale.json')}});
     config.extensions = getInstalledExtensionIds();
     await uploadConfigToGDrive(config);
 


### PR DESCRIPTION
There was an error when the files "keybindings.json" and "locale.json" not exists. They do not exists when the vscode user have not changed the keybindings or something in the language settings.

I have tested this. It works.